### PR TITLE
Fix site.manifest

### DIFF
--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -385,7 +385,7 @@ const Home = ({serverSideApiKeyIsSet, serverSidePluginKeysSet, defaultModelId}: 
         <link rel="apple-touch-icon" sizes="180x180" href={`${router.basePath}/apple-touch-icon.png`} />
         <link rel="icon" type="image/png" sizes="32x32" href={`${router.basePath}/favicon-32x32.png`} />
         <link rel="icon" type="image/png" sizes="16x16" href={`${router.basePath}/favicon-16x16.png`} />
-        <link rel="manifest" href={`${router.basePath}/site.webmanifest`} />
+        <link rel="manifest" href={`${router.basePath}/site.webmanifest`} crossOrigin="use-credentials" />
         <link rel="mask-icon" href={`${router.basePath}/safari-pinned-tab.svg`} color="#884444" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />


### PR DESCRIPTION
use-credentials
A cross-origin request (i.e. with an Origin HTTP header) is performed along with a credential sent (i.e. a cookie, certificate, and/or HTTP Basic authentication is performed).