### PR TITLE
Make code blocks wider in all messages

### DIFF
--- a/components/Chat/MessageMarkdown.tsx
+++ b/components/Chat/MessageMarkdown.tsx
@@ -15,7 +15,7 @@ interface Props {
 const MessageMarkdown = ({message, isComplete}: Props) => {
   return (
     <MemoizedReactMarkdown
-      className="prose flex-1 dark:prose-invert"
+      className="prose flex-1 dark:prose-invert markdown"
       remarkPlugins={[
         [remarkGfm, {}],
         [

--- a/components/Chat/MessageRow.tsx
+++ b/components/Chat/MessageRow.tsx
@@ -9,7 +9,7 @@ interface Props {
 const MessageRow = ({className, icon, children}: Props) => {
   return (
     <div className={className} style={{overflowWrap: "anywhere"}}>
-      <div className="relative m-auto flex max-w-2xl gap-2 p-4 px-0 py-4 text-base">
+      <div className="relative m-auto flex sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg gap-2 p-4 px-0 py-4 text-base">
         <div className="min-w-[40px] text-right font-bold">{icon}</div>
         <div className="prose mt-[-2px] w-full dark:prose-invert">{children}</div>
       </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,6 +42,23 @@ pre:has(div.codeblock) {
   padding: 0;
 }
 
+.markdown {
+  width: 100%;
+}
+
+.markdown > * {
+  /* Equivalent of max-w-prose from tailwindcss. */
+  max-width: 65ch;
+  justify-self: center;
+  /* Equivalent of mx-auto from tailwindcss. */
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.markdown > pre {
+  max-width: 100%
+}
+
 .error-message {
   color: indianred;
 }


### PR DESCRIPTION
This should address #141 in the sense that it preserves a good width for reading the markdown-rendered text and allows the code blocks to grow as wide as the Message itself.

I did not want to let the actual text-only conversation to grow as wide as the code-block because it reduces readability, especially on wide screens.

I played with the width settings on MessageRow and I only validated `md:max-w-screen-md lg:max-w-screen-lg` to be good-looking. I am expecting the bigger sizes would also work, but I did not want to add them without testing. Furthermore, having a huge difference between the wide code blocks and the rest of the text would also reduce readability.

Finally... this change is a bit of a workaround directly in `globals.css` because the `.markdown > *` CSS rule does not have an easy equivalent in the code. Unfortunately, react-markdown does not have a way to put a common class style on all components, except some. The other 2 alternatives I thought about:
- Override all HTML tags generated by react-markdown (p, a, lists, headers, etc.). This is doable, but it looks cumbersome in the code, plus it might require changes in case react-markdown will start using other HTML tags.
- Parse the message content and split on the "```" sperator, creating a list of (codeblock, non-codeblock) elements. The parsing would look a bit hacky, but it would allow greater flexibility with applying styles on these pieces separately. If interested, I can prepare a PR doing this.