### PR TITLE
Add support for open-ai reasoning models like o3-mini, o1

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -14,6 +14,9 @@ OPENAI_MAX_TOKENS=1000
 OPENAI_DEFAULT_MODEL=gpt-35-turbo
 OPENAI_AZURE_DEPLOYMENT_ID=dep-...
 
+# Log requests and response from openai library when set to true. helpful for debugging
+DEBUG=false
+
 # OpenAI
 # OPENAI_API_TYPE=openai
 # OPENAI_API_KEY=...

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -107,7 +107,8 @@ const Chat = memo(({stopConversationRef}: Props) => {
         apiKey: apiKey,
         prompt: updatedConversation.prompt,
         temperature: updatedConversation.temperature,
-        outputTokenLimit: updatedConversation.maxTokens
+        outputTokenLimit: updatedConversation.maxTokens,
+        reasoningEffort: updatedConversation.reasoningEffort
       }
       const endpoint = getEndpoint(plugin)
       let body

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/jest": "^29.5.14",
     "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.13.13",
+    "@types/node": "^22.14.0",
     "@types/react": "^18.3.20",
     "@types/react-dom": "^18.3.5",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/pages/api/chat.api.ts
+++ b/pages/api/chat.api.ts
@@ -48,7 +48,7 @@ const encoder = TiktokenEncoder.wrap(cl100k_base)
 
 const handler = async (req: Request): Promise<Response> => {
   try {
-    const {messages, apiKey, modelId, prompt, temperature, outputTokenLimit} = (await req.json()) as ChatBody
+    const {messages, apiKey, modelId, prompt, temperature, outputTokenLimit, reasoningEffort} = (await req.json()) as ChatBody
     const inputTokenLimit = maxInputTokensForModel(modelId)
 
     const maxReplyTokensToUse = outputTokenLimit || OPENAI_API_MAX_TOKENS
@@ -81,7 +81,9 @@ maxTokens:${maxReplyTokensToUse}}`)
       temperatureToUse,
       maxReplyTokensToUse,
       apiKey,
-      messagesToSend
+      messagesToSend,
+      false,
+      reasoningEffort
     )
   } catch (error) {
     if (error instanceof OpenAIRateLimited) {

--- a/pages/api/home/home.tsx
+++ b/pages/api/home/home.tsx
@@ -41,6 +41,7 @@ import {cleanConversationHistory, cleanSelectedConversation} from "@/utils/app/c
 import {
   NEW_CONVERSATION_TITLE,
   OPENAI_ALLOW_MODEL_SELECTION,
+  OPENAI_DEFAULT_REASONING_EFFORT,
   OPENAI_DEFAULT_TEMPERATURE,
   OPENAI_REUSE_MODEL
 } from "@/utils/app/const"
@@ -213,7 +214,8 @@ const Home = ({
             ? lastConversation?.modelId ?? defaultModelId
             : defaultModelId
           : defaultModelId,
-        lastConversation?.temperature ?? OPENAI_DEFAULT_TEMPERATURE
+        lastConversation?.temperature ?? OPENAI_DEFAULT_TEMPERATURE,
+        lastConversation?.reasoningEffort ?? OPENAI_DEFAULT_REASONING_EFFORT
       )
       const updatedConversations = [...conversations, newConversation]
       homeDispatch({field: "selectedConversation", value: newConversation})
@@ -439,7 +441,8 @@ const Home = ({
                 ? lastConversation?.modelId ?? defaultModelId
                 : defaultModelId
               : defaultModelId,
-            lastConversation?.temperature ?? OPENAI_DEFAULT_TEMPERATURE
+            lastConversation?.temperature ?? OPENAI_DEFAULT_TEMPERATURE,
+            lastConversation?.reasoningEffort ?? OPENAI_DEFAULT_REASONING_EFFORT
           )
           // Only add a new conversation to the history if there are existing conversations.
           if (cleanedConversationHistory.length > 0) {

--- a/pages/api/models.api.ts
+++ b/pages/api/models.api.ts
@@ -15,7 +15,7 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import {OpenAIModel, maxInputTokensForModel, maxOutputTokensForModel} from "@/types/openai"
+import {OpenAIModel, maxInputTokensForModel, maxOutputTokensForModel, isOpenAiReasoningModel} from "@/types/openai"
 import {OPENAI_API_HOST, OPENAI_API_TYPE, OPENAI_API_VERSION, OPENAI_ORGANIZATION} from "@/utils/app/const"
 
 export const config = {
@@ -60,14 +60,12 @@ const handler = async (req: Request): Promise<Response> => {
         return {
           id: model.id,
           inputTokenLimit: maxInputTokensForModel(model.id),
-          outputTokenLimit: maxOutputTokensForModel(model.id)
-        }
+          outputTokenLimit: maxOutputTokensForModel(model.id),
+          isOpenAiReasoningModel: isOpenAiReasoningModel(model.id), 
+        };
       })
-      // Filter "falsy" items:
       .filter(Boolean)
-      // Filter out unsupported models:
       .filter((model: OpenAIModel) => model.inputTokenLimit > 0)
-      // Filter out duplicate models:
       .filter((model: OpenAIModel) => {
         if (uniqueModelIds.has(model.id)) {
           return false

--- a/types/chat.ts
+++ b/types/chat.ts
@@ -20,7 +20,7 @@
  * Note that the names of properties in this file are
  * dictated by the API interface of OpenAI.
  */
-export type Role = "system" | "assistant" | "user" | "tool"
+export type Role = "system" | "assistant" | "user" | "tool" | "developer"
 
 export interface MessagePartText {
   type: "text"
@@ -46,7 +46,7 @@ export interface UserMessage {
 }
 
 export interface SystemMessage {
-  role: "system"
+  role: "system" | "developer"
   content: string
   name?: string
 }
@@ -74,6 +74,7 @@ export interface ChatBody {
   prompt: string
   temperature: number
   outputTokenLimit: number
+  reasoningEffort?: string
 }
 
 // This type is used to store a conversation in the store.
@@ -88,6 +89,7 @@ export interface Conversation {
   maxTokens: number
   folderId: string | undefined
   time: number
+  reasoningEffort?: string
 }
 
 export const getMessageAsString = (message: Message): string => {
@@ -136,6 +138,8 @@ export const createMessage = (role: string, content: any): Message => {
   if (role === "user") {
     return {role, content: [{type: "text", text: content}]}
   } else if (role === "system") {
+    return {role, content}
+  } else if (role === "developer") {
     return {role, content}
   } else if (role === "assistant") {
     return {role, content}

--- a/types/openai.ts
+++ b/types/openai.ts
@@ -25,9 +25,10 @@
  */
 
 export interface OpenAIModel {
-  id: string // The model identifier.
-  inputTokenLimit: number // The maximum number of input tokens for this model; if 0, the model is not supported.
-  outputTokenLimit: number // The maximum number of input tokens for this model; if 0, the model is not supported.
+  id: string; // The model identifier.
+  inputTokenLimit: number; // The maximum number of input tokens for this model; if 0, the model is not supported.
+  outputTokenLimit: number; // The maximum number of output tokens for this model; if 0, the model is not supported.
+  openAiReasoningModel?: boolean; // Indicates if the model is an OpenAI reasoning model like o1 or o3-mini
 }
 
 const K4 = 4 * 1024
@@ -45,7 +46,8 @@ export const OpenAIModels: Record<string, OpenAIModel> = {
   ["gpt-4-turbo-preview"]: {id: "gpt-4-turbo-preview", inputTokenLimit: K128, outputTokenLimit: K4},
   ["gpt-4-turbo"]: {id: "gpt-4-turbo", inputTokenLimit: K128, outputTokenLimit: K4},
   ["gpt-4o"]: {id: "gpt-4o", inputTokenLimit: K128, outputTokenLimit: K4},
-  ["gpt-4o-mini"]: {id: "gpt-4o-mini", inputTokenLimit: K128, outputTokenLimit: K16}
+  ["gpt-4o-mini"]: {id: "gpt-4o-mini", inputTokenLimit: K128, outputTokenLimit: K16},
+  ["o3-mini"]: {id: "o3-mini", inputTokenLimit: K128, outputTokenLimit: K32, openAiReasoningModel: true}
 }
 
 export const maxInputTokensForModel = (modelId: string) => {
@@ -54,6 +56,10 @@ export const maxInputTokensForModel = (modelId: string) => {
 
 export const maxOutputTokensForModel = (modelId: string) => {
   return OpenAIModels[modelId]?.outputTokenLimit ?? 0
+}
+
+export const isOpenAiReasoningModel = (modelId: string) => {
+  return OpenAIModels[modelId]?.openAiReasoningModel ?? false
 }
 
 export const FALLBACK_OPENAI_MODEL = "gpt-35-turbo"

--- a/utils/app/clean.ts
+++ b/utils/app/clean.ts
@@ -16,7 +16,7 @@
  * SOFTWARE.
  */
 
-import {OPENAI_DEFAULT_SYSTEM_PROMPT, OPENAI_DEFAULT_TEMPERATURE} from "./const"
+import {OPENAI_DEFAULT_REASONING_EFFORT, OPENAI_DEFAULT_SYSTEM_PROMPT, OPENAI_DEFAULT_TEMPERATURE} from "./const"
 import {Conversation} from "@/types/chat"
 import {OpenAIModel} from "@/types/openai"
 
@@ -49,6 +49,12 @@ export const cleanSelectedConversation = (
     updatedConversation = {
       ...updatedConversation,
       temperature: updatedConversation.temperature ?? OPENAI_DEFAULT_TEMPERATURE
+    }
+  }
+  if (updatedConversation.reasoningEffort === undefined || updatedConversation.reasoningEffort === null) {
+    updatedConversation = {
+      ...updatedConversation,
+      reasoningEffort: updatedConversation.reasoningEffort ?? OPENAI_DEFAULT_REASONING_EFFORT
     }
   }
   if (!updatedConversation.folderId) {

--- a/utils/app/const.ts
+++ b/utils/app/const.ts
@@ -59,3 +59,5 @@ export const OPENAI_ALLOW_MODEL_SELECTION =
 
 // Other constants.
 export const NEW_CONVERSATION_TITLE = "New conversation"
+
+export const OPENAI_DEFAULT_REASONING_EFFORT = process.env.OPENAI_DEFAULT_REASONING_EFFORT ?? "medium"

--- a/utils/app/conversations.ts
+++ b/utils/app/conversations.ts
@@ -20,13 +20,13 @@ import {v4 as uuidv4} from "uuid"
 
 import {Conversation} from "@/types/chat"
 import {maxOutputTokensForModel} from "@/types/openai"
-import {OPENAI_API_MAX_TOKENS, OPENAI_DEFAULT_SYSTEM_PROMPT, OPENAI_DEFAULT_TEMPERATURE} from "@/utils/app/const"
+import {OPENAI_API_MAX_TOKENS, OPENAI_DEFAULT_REASONING_EFFORT, OPENAI_DEFAULT_SYSTEM_PROMPT, OPENAI_DEFAULT_TEMPERATURE} from "@/utils/app/const"
 import {localStorageSafeGetItem, localStorageSafeRemoveItem, localStorageSafeSetItem} from "@/utils/app/storage"
 
 export const LOCAL_STORAGE_SELECTED_CONVERSATION = "selectedConversation"
 export const STORAGE_KEY_HISTORY = "history"
 
-export const createNewConversation = (name: string, modelId: string, temperature: number): Conversation => {
+export const createNewConversation = (name: string, modelId: string, temperature: number, reasoningEffort: string): Conversation => {
   return {
     id: uuidv4(),
     name: name,
@@ -35,9 +35,10 @@ export const createNewConversation = (name: string, modelId: string, temperature
     modelId: modelId,
     prompt: OPENAI_DEFAULT_SYSTEM_PROMPT,
     temperature: temperature || OPENAI_DEFAULT_TEMPERATURE,
-    maxTokens: OPENAI_API_MAX_TOKENS,
+    maxTokens: maxOutputTokensForModel(modelId) || OPENAI_API_MAX_TOKENS,
     folderId: undefined,
-    time: new Date().getTime()
+    time: new Date().getTime(),
+    reasoningEffort: reasoningEffort || OPENAI_DEFAULT_REASONING_EFFORT
   }
 }
 

--- a/utils/server/openAiClient.ts
+++ b/utils/server/openAiClient.ts
@@ -21,6 +21,8 @@ import OpenAI from "openai"
 import {OPENAI_API_HOST, OPENAI_API_TYPE, OPENAI_AZURE_DEPLOYMENT_ID, OPENAI_ORGANIZATION} from "../app/const"
 import {Message} from "@/types/chat"
 import {getAzureDeploymentIdForModelId} from "@/utils/app/azure"
+import { isOpenAiReasoningModel } from "@/types/openai"
+import { ReasoningEffort } from "openai/resources/shared"
 
 export class OpenAIError extends Error {
   constructor(message: string) {
@@ -105,7 +107,8 @@ export const ChatCompletionStream = async (
   maxTokens: number,
   apiKey: string,
   messages: Message[],
-  dangerouslyAllowBrowser = false
+  dangerouslyAllowBrowser = false,
+  reasoningEffort?: string
 ) => {
   const configuration = createOpenAiConfiguration(apiKey, modelId, dangerouslyAllowBrowser)
   const openai = createOpenAiClient(configuration)
@@ -114,15 +117,30 @@ export const ChatCompletionStream = async (
     throw new Error("No messages in history")
   }
 
+  // Check if the model is a reasoning model
+  const isReasoningModel = isOpenAiReasoningModel(modelId)
+
   // Ask OpenAI for a streaming chat completion given the prompt
   try {
     const response = await openai.chat.completions.create({
       model: modelId,
-      messages: [{role: "system", content: systemPrompt}, ...messages],
-      max_tokens: maxTokens,
-      temperature: temperature,
+      messages: [
+        {
+          role: isReasoningModel ? "developer" : "system",
+          content: systemPrompt
+        }, ...messages],
+      ...(isReasoningModel
+        ? {
+            reasoning_effort: reasoningEffort as ReasoningEffort,
+            max_completion_tokens: maxTokens
+        }
+        : {
+            temperature, 
+            max_tokens: maxTokens,
+        }),
       stream: true
     })
+    .asResponse()
 
     // Convert the response into a friendly text-stream
     const stream = OpenAIStream(response)


### PR DESCRIPTION
[Azure OpenAI reasoning models Feature Support](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/reasoning?tabs=python-secure#api--feature-support)

1. Add reasoning models that have support for `System Messages` (via developer messages) 
            - o1
            - o3-mini